### PR TITLE
Remove gwpy from /projects/training/pyproject.toml.

### DIFF
--- a/projects/train/pyproject.toml
+++ b/projects/train/pyproject.toml
@@ -20,9 +20,6 @@ jsonargparse = {version = "^4.17", extras = ["signatures"]}
 ml4gw = {path = "../../toolbox/ml4gw", develop = true}
 utils = {path = "../utils", develop = true}
 
-# gwpy
-gwpy = "^3.0"
-
 [[tool.poetry.source]]
 name = "torch"
 url = "https://download.pytorch.org/whl/cu121"


### PR DESCRIPTION
Since we don't need gwpy during training and gwpy will cause trouble when building apptainer image, gwpy is removed from the pyproject.toml.